### PR TITLE
fix null data restoration/23.0.1 build tools/Db+Cursor Close&Open

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "com.udacity.pathfinder.android.udacitypathfinder"
@@ -33,26 +33,19 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:recyclerview-v7:23.1.1'
-    compile 'com.android.support:cardview-v7:23.1.1'
-    compile 'com.android.support:design:23.1.1'
-
+    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:recyclerview-v7:23.0.1'
+    compile 'com.android.support:cardview-v7:23.0.1'
+    compile 'com.android.support:design:23.0.1'
     compile 'com.jakewharton:butterknife:7.0.1'
     compile 'com.jakewharton.timber:timber:4.0.1'
-
     compile 'org.jsoup:jsoup:1.7.2'
-
     compile 'com.github.bumptech.glide:glide:3.6.1'
-
     compile 'com.github.paolorotolo:appintro:3.2.0'
-
     compile 'com.google.android.gms:play-services-identity:8.1.0'
     compile 'com.google.android.gms:play-services-plus:8.1.0'
-
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.squareup.okhttp:okhttp:2.2.0'
-
     compile 'com.facebook.android:facebook-android-sdk:4.2.0'
     compile fileTree('libs/ParseFacebookUtilsV4-1.10.3.jar')
     compile 'com.parse:parse-android:1.10.2'


### PR DESCRIPTION
When user would login the method to restore data would trigger. Yet, if an article
has been removed from dataset backend the restoration would attempt to restore
an article with null. Resolved this issue by simply checking for null.

Build tools 23.0.2 would cause screen lockup when attempting to scroll. To
resolved we had to backdate both build tools and support library to v23.0.1

Local Database with DbArticleLikes was working. However, it seems best practice
to open database then close it.